### PR TITLE
Fix filenames with spaces

### DIFF
--- a/BmsDefinitionReductor/Class/BmsManager.cs
+++ b/BmsDefinitionReductor/Class/BmsManager.cs
@@ -83,7 +83,7 @@ namespace BmsDefinitionReductor.Class
         /// <returns>定義番号とwavファイル名</returns>
         static public (string, string) GetWavData(string line)
         {
-            string[] arr = line.Split(' ');
+            string[] arr = line.Split(new[] { ' ' }, 2);
             return (arr[0].Substring(4, 2), arr[1]);
         }
 


### PR DESCRIPTION
(message is in english, sorry in advance 🙇‍♀️)

Thank you very much for this very nice piece of software! The current version does not support WAV definitions that have spaces in the filename (e.g. `#WAV01 test 01.wav`); this pull requests proposes a quick fix to remediate to that in `GetWavData`, by replacing `string[] arr = line.Split(' ');` with `string[] arr = line.Split(new[] { ' ' }, 2);`.

Thank you in advance!

